### PR TITLE
Fix fish_prompt to display outside any repository directries

### DIFF
--- a/.config/fish/functions/fish_prompt.fish
+++ b/.config/fish/functions/fish_prompt.fish
@@ -1,5 +1,11 @@
 function fish_prompt
+  set_color cyan
+  printf '%s' (pwd)
   # Git
   set last_status $status
-  echo -n (set_color cyan)(pwd)(set_color green)(__fish_git_prompt)(set_color normal)'❯ '
+  set_color green
+  printf '%s' (__fish_git_prompt)
+  
+  set_color normal
+  printf '❯ '
 end


### PR DESCRIPTION
Fix for bug: In the case of a directory that is not a Git repository, the pathname will no longer be displayed.